### PR TITLE
Bugfix in Postmark adapter - unknown PHP function array_get()

### DIFF
--- a/src/Adapters/Postmark.php
+++ b/src/Adapters/Postmark.php
@@ -39,7 +39,7 @@ class Postmark extends AbstractAdapter
             return $this->eventMap[ Arr::get($this->payload, 'Type') ];
         }
 
-        return array_get($this->eventMap, Arr::get($this->payload, 'RecordType'));
+        return Arr::get($this->eventMap, Arr::get($this->payload, 'RecordType'));
     }
 
     /**


### PR DESCRIPTION
Unknown PHP function creating error on Postmark webhook.

Changed array_get() to Arr::get()